### PR TITLE
Max/add passable envs and bucket by key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+.env
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-.env
 *.log

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rhinocloud-sdk
-Rhinocloud-sdk acts as an abstraction layer for the `aws-sdk` that uses JavaScript-friendly syntax, such as camel case functions 
+Rhinocloud-sdk acts as an abstraction layer for the `aws-sdk` that uses JavaScript-friendly syntax, such as camel case functions
 and parameters; Rhinogram uses this tool to make deploying CloudFormation easy and painless. Rhinocloud-sdk is meant to be
 a lightweight, micro package to make developing in AWS as easy as possible.
 
@@ -10,10 +10,14 @@ a lightweight, micro package to make developing in AWS as easy as possible.
 ```bash
 import Rhinocloud from 'rhinocloud-sdk';
 
-const rhinocloud = new Rhinocloud();
+const rhinocloud = new Rhinocloud({
+  accessKeyId: < Your AWS Access Key Id >,
+  secretAccessKey: < Your AWS Secret Key >,
+  region: < AWS Region >,
+  });
 ```
 
-* Note: AWS Environment keys must be set before instantiating a new instance:
+* OR You can use AWS Environment keys before instantiating a new instance:
   * `AWS_ACCESS_KEY_ID`
   * `AWS_SECRET_ACCESS_KEY`
   * `AWS_REGION`
@@ -69,7 +73,7 @@ Parameters:
 Resources:
   Bucket:
     Type: AWS::S3::Bucket
-    Properties: 
+    Properties:
       AccessControl: 'Public'
       BucketName: !Ref 'Name'
       Tags:

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ logAllBucketsInAccount();
     * `ID` (string)
 #### arguments
   * `bucketName` (string) `required`: Name of the S3 Bucket to get bucket contents.
-  * `key` (string) `optional` : Name of the Object/Key to get - this can be a folder path or file.
+  * `s3ObjectName` (string) `optional` : Name of the folder/file to get - this is a path to a file or folder with '/' Delimiter.
 #### Example
 ```bash
 async function logBucketContents(name) {

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ logAllBucketsInAccount();
     * `DisplayName` (string)
     * `ID` (string)
 #### arguments
-  * `bucketName` (string): Name of the S3 Bucket to get bucket contents.
+  * `bucketName` (string) `required`: Name of the S3 Bucket to get bucket contents.
+  * `key` (string) `optional` : Name of the Object/Key to get - this can be a folder path or file.
 #### Example
 ```bash
 async function logBucketContents(name) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const CloudFormationWrapper = require('./library/cloudformation');
 const S3Wrapper = require('./library/s3');
 
-function Rhinocloud({ accessKeyId, secretAccessKey, region }) {
+function Rhinocloud({ accessKeyId = undefined, secretAccessKey = undefined, region = undefined } ={}) {
   this.cloudformation = new CloudFormationWrapper({ accessKeyId, secretAccessKey, region });
   this.s3 = new S3Wrapper({ accessKeyId, secretAccessKey, region });
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const CloudFormationWrapper = require('./library/cloudformation');
 const S3Wrapper = require('./library/s3');
 
-function Rhinocloud({ accessKeyId = undefined, secretAccessKey = undefined, region = undefined } ={}) {
+function Rhinocloud({ accessKeyId = undefined, secretAccessKey = undefined, region = undefined } = {}) {
   this.cloudformation = new CloudFormationWrapper({ accessKeyId, secretAccessKey, region });
   this.s3 = new S3Wrapper({ accessKeyId, secretAccessKey, region });
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const CloudFormationWrapper = require('./library/cloudformation');
 const S3Wrapper = require('./library/s3');
-const dotenv =  require('dotenv').config()
 
 function Rhinocloud({ accessKeyId, secretAccessKey, region }) {
   this.cloudformation = new CloudFormationWrapper({ accessKeyId, secretAccessKey, region });

--- a/index.js
+++ b/index.js
@@ -2,23 +2,9 @@ const CloudFormationWrapper = require('./library/cloudformation');
 const S3Wrapper = require('./library/s3');
 const dotenv =  require('dotenv').config()
 
-function Rhinocloud() {
-  this.cloudformation = new CloudFormationWrapper();
-  this.s3 = new S3Wrapper();
-}
-
-Rhinocloud.prototype.setKeys = function(awsAccesKeyId, awsSecretKey, awsRegion) {
-  this.awsAccesKeyId = awsAccesKeyId;
-  this.awsSecretKey = awsSecretKey;
-  this.awsRegion = awsRegion;
-}
-
-Rhinocloud.prototype.getKeys = function() {
-  return {
-    awsAccesKeyId: this.awsAccesKeyId,
-    awsSecretKey: this.awsSecretKey,
-    awsRegion: this.awsRegion,
-  };
+function Rhinocloud({ accessKeyId, secretAccessKey, region }) {
+  this.cloudformation = new CloudFormationWrapper({ accessKeyId, secretAccessKey, region });
+  this.s3 = new S3Wrapper({ accessKeyId, secretAccessKey, region });
 }
 
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,26 @@
 const CloudFormationWrapper = require('./library/cloudformation');
 const S3Wrapper = require('./library/s3');
+const dotenv =  require('dotenv').config()
 
 function Rhinocloud() {
   this.cloudformation = new CloudFormationWrapper();
   this.s3 = new S3Wrapper();
 }
+
+Rhinocloud.prototype.setKeys = function(awsAccesKeyId, awsSecretKey, awsRegion) {
+  this.awsAccesKeyId = awsAccesKeyId;
+  this.awsSecretKey = awsSecretKey;
+  this.awsRegion = awsRegion;
+}
+
+Rhinocloud.prototype.getKeys = function() {
+  return {
+    awsAccesKeyId: this.awsAccesKeyId,
+    awsSecretKey: this.awsSecretKey,
+    awsRegion: this.awsRegion,
+  };
+}
+
 
 Rhinocloud.prototype = Object.create(Rhinocloud.prototype);
 Rhinocloud.prototype.constructor = Rhinocloud;

--- a/library/cloudformation/index.js
+++ b/library/cloudformation/index.js
@@ -13,6 +13,8 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
 
   // -------------------------- API functions ---------------------------- //
   async function changeTerminationProtection({ stackName, enableTerminationProtection } = {}) {
+    if (!templatePath || !enableTerminationProtection) {
+      throw new Error(`Must include enableTerminationProtection (string) and stackName (string) for CloudFormation`);
     const updateParams = {
       StackName: stackName,
       EnableTerminationProtection: enableTerminationProtection

--- a/library/cloudformation/index.js
+++ b/library/cloudformation/index.js
@@ -12,7 +12,7 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
   });
 
   // -------------------------- API functions ---------------------------- //
-  async function changeTerminationProtection({ stackName, enableTerminationProtection }) {
+  async function changeTerminationProtection({ stackName, enableTerminationProtection } = {}) {
     const updateParams = {
       StackName: stackName,
       EnableTerminationProtection: enableTerminationProtection
@@ -21,7 +21,7 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
     return resp;
   }
 
-  async function cloudForm({ templatePath, stackName, options={} }) {
+  async function cloudForm({ templatePath, stackName, options={} } = {}) {
     if (!templatePath || !stackName) {
       throw new Error(`Must include templatePath (string) and stackName (string) for CloudFormation`);
     } else {
@@ -56,7 +56,7 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
     return resp;
   }
 
-  async function deleteStack({ stackName, options={} }) {
+  async function deleteStack({ stackName, options={} } = {}) {
     const deleteParams = { StackName: stackName };
     const resp = await cf.deleteStack(deleteParams).promise();
     const { waitToComplete, stdout } = paramTools.getOptions(options);

--- a/library/cloudformation/index.js
+++ b/library/cloudformation/index.js
@@ -3,8 +3,13 @@ const { CloudFormation } = require('aws-sdk');
 const apiVersions = require('../../apiVersions.json');
 const paramTools = require('./toolbox/parameter.tools');
 
-function CloudFormationWrapper() {
-  const cf = new CloudFormation({ apiVersion: apiVersions.CloudFormation });
+function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
+  const cf = new CloudFormation({
+    apiVersion: apiVersions.CloudFormation,
+    accessKeyId,
+    secretAccessKey,
+    region
+  });
 
   // -------------------------- API functions ---------------------------- //
   async function changeTerminationProtection({ stackName, enableTerminationProtection }) {

--- a/library/cloudformation/index.js
+++ b/library/cloudformation/index.js
@@ -47,6 +47,8 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
   }
 
   async function createStack(templatePath, stackName, parameters=[], enableTerminationProtection) {
+    if (!templatePath || !stackName) {
+      throw new Error(`Must include templatePath (string) and stackName (string) for CloudFormation`);
     const params = {
       StackName: stackName,
       TemplateBody: fs.readFileSync(templatePath, 'utf-8'),
@@ -59,6 +61,9 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
   }
 
   async function deleteStack({ stackName, options={} } = {}) {
+    if (!stackName) {
+      throw new Error(`Must include stackName (string) for CloudFormation`)
+    }
     const deleteParams = { StackName: stackName };
     const resp = await cf.deleteStack(deleteParams).promise();
     const { waitToComplete, stdout } = paramTools.getOptions(options);
@@ -78,11 +83,17 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
   }
 
   async function getStackOutputs(stackName='') {
+    if (!stackName) {
+      throw new Error(`Must include stackName (string) for CloudFormation`)
+    }
     const { Stacks } = await cf.describeStacks({ StackName: stackName }).promise();
     return Stacks.pop();
   }
 
   async function stackExists (stackName='') {
+    if (!stackName) {
+      throw new Error(`Must include stackName (string) for CloudFormation`)
+    }
     try {
       const { Stacks } = await cf.describeStacks({ StackName: stackName }).promise();
       return Stacks.length > 0;
@@ -97,6 +108,9 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
   }
 
   async function updateStack(stackName, templatePath, parameters=[], stdout) {
+    if (!stackName || !templatePath) {
+      throw new Error(`Must include stackName (string) and templatesPath (string) for CloudFormation`)
+    }
     try {
       const updateParams = {
         StackName: stackName,
@@ -118,6 +132,9 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
 
 
   async function waitOnStackToStabilize(stackName, stdout, retry=0) {
+    if (!stackName) {
+      throw new Error(`Must include stackName (string) for CloudFormation`)
+    }
     const describeParams = { StackName: stackName };
     const WAIT_INTERVAL = 5000;
     if (retry < 240) {

--- a/library/cloudformation/index.js
+++ b/library/cloudformation/index.js
@@ -13,7 +13,7 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
 
   // -------------------------- API functions ---------------------------- //
   async function changeTerminationProtection({ stackName, enableTerminationProtection } = {}) {
-    if (!templatePath || !enableTerminationProtection) {
+    if (!stackName || !enableTerminationProtection) {
       throw new Error(`Must include enableTerminationProtection (string) and stackName (string) for CloudFormation`);
     const updateParams = {
       StackName: stackName,
@@ -25,7 +25,7 @@ function CloudFormationWrapper({ accessKeyId, secretAccessKey, region }) {
 
   async function cloudForm({ templatePath, stackName, options={} } = {}) {
     if (!templatePath || !stackName) {
-      throw new Error(`Must include templatePath (string) and stackName (string) for CloudFormation`);
+      throw new Error(`Must include stackName (string) and templatePath (string) for CloudFormation`);
     } else {
       const fileExists = fs.existsSync(templatePath);
       if (!fileExists) {

--- a/library/s3/index.js
+++ b/library/s3/index.js
@@ -24,11 +24,8 @@ function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
   async function getBucket({ bucket='', prefix = undefined } = {}) {
     const listParams = {
       Bucket: bucket,
+      ...!!prefix && { Delimiter: '/', Prefix: prefix },
     };
-     if (prefix) {
-       listParams.Prefix = prefix;
-       listParams.Delimiter = '/';
-     }
     const { Contents } = await s3.listObjects(listParams).promise();
     return Contents;
   }

--- a/library/s3/index.js
+++ b/library/s3/index.js
@@ -21,11 +21,14 @@ function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
     return Buckets;
   }
 
-  async function getBucket({ bucket='', key = undefined } = {}) {
+  async function getBucket({ bucket='', prefix = undefined } = {}) {
     const listParams = {
       Bucket: bucket,
-      ...!!key && { Delimiter: '/', Prefix: key },
     };
+     if (prefix) {
+       listParams.Prefix = prefix;
+       listParams.Delimiter = '/';
+     }
     const { Contents } = await s3.listObjects(listParams).promise();
     return Contents;
   }

--- a/library/s3/index.js
+++ b/library/s3/index.js
@@ -21,13 +21,16 @@ function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
     return Buckets;
   }
 
-  async function getBucket(bucket='') {
-    const listParams = { Bucket: bucket };
+  async function getBucket({ bucket='', key = undefined } = {}) {
+    const listParams = {
+      Bucket: bucket,
+      ...!!key && { Delimiter: key },
+    };
     const { Contents } = await s3.listObjects(listParams).promise();
     return Contents;
   }
 
-  async function downloadS3File({ bucket, s3FileName, destinationFileName }) {
+  async function downloadS3File({ bucket, s3FileName, destinationFileName } = {}) {
     if (!bucket || !s3FileName || !destinationFileName) {
       rej(`downloadS3File() requires parameters properties`);
     }
@@ -39,7 +42,7 @@ function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
     await writeFileFromStream(readStream, destinationFileName);
   }
 
-  async function uploadS3Directory({ bucket, s3Location, sourceDirectory, options={} }) {
+  async function uploadS3Directory({ bucket, s3Location, sourceDirectory, options={} } = {}) {
     if (!bucket || (s3Location === undefined || s3Location === null) || !sourceDirectory) {
       throw new Error(`uploadS3Directory() requires parameters properties: bucket, s3Location, and sourceDirectory`);
     } else {
@@ -58,7 +61,7 @@ function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
     }
   }
 
-  async function uploadS3File({ bucket, s3FileName, sourceFileName, options={} }) {
+  async function uploadS3File({ bucket, s3FileName, sourceFileName, options={} } = {}) {
     if (!bucket || !s3FileName || !sourceFileName) {
       throw new Error(`uploadS3File() requires parameters properties: bucket, s3FileName, and sourceFileName`);
     } else {
@@ -68,7 +71,7 @@ function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
     }
   }
 
-  async function moveS3Directory({ sourceBucket, s3SourceDirectory, destinationBucket, s3DestinationDirectory, options={} }) {
+  async function moveS3Directory({ sourceBucket, s3SourceDirectory, destinationBucket, s3DestinationDirectory, options={} } = {}) {
     if (!sourceBucket || !s3SourceDirectory || !destinationBucket || (s3DestinationDirectory !== '' && !s3DestinationDirectory)) {
       throw new Error(`moveS3Directory() requires parameters: sourceBucket, s3SourceDirectory, destinationBucket, and s3DestinationDirectory`);
     } else {
@@ -101,7 +104,7 @@ function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
     }
   }
 
-  async function moveS3File({ sourceBucket, s3SourceFile, destinationBucket, s3DestinationFile, options={} }) {
+  async function moveS3File({ sourceBucket, s3SourceFile, destinationBucket, s3DestinationFile, options={} } = {}) {
     if (!sourceBucket || !s3SourceFile || !destinationBucket || !s3DestinationFile) {
       throw new Error(`moveS3File() requires parameters properties: sourceBucket, s3SourceFile, s3DestinationFile, and destinationBucket`);
     } else {

--- a/library/s3/index.js
+++ b/library/s3/index.js
@@ -1,6 +1,5 @@
 const { S3 } = require('aws-sdk');
 const apiVersions = require('../../apiVersions.json');
-const RhinoCloud = require('../index');
 const { getS3UploadParameters, getS3MoveParameters } = require('./toolbox/action.tools');
 const {
   getFilePathsFromDirectory,
@@ -8,8 +7,13 @@ const {
   getFileNameFromS3Key
 } = require('./toolbox/file.tools');
 
-function s3Wrapper() {
-  const s3 = new S3({ apiVersion: apiVersions.S3 });
+function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
+  const s3 = new S3({
+    apiVersion: apiVersions.S3,
+    accessKeyId,
+    secretAccessKey,
+    region
+  });
 
   // ---------------------------- API functions --------------------------- //
   async function listBuckets() {
@@ -129,8 +133,7 @@ function s3Wrapper() {
 }
 
 // ------------------------------- export ----------------------------- //
-s3Wrapper.prototype = Object.create(RhinoCloud.prototype);
+s3Wrapper.prototype = Object.create(s3Wrapper.prototype);
 s3Wrapper.prototype.constructor = s3Wrapper;
-s3Wrapper.getKeys = RhinoCloud.getKeys;
 
 module.exports = s3Wrapper;

--- a/library/s3/index.js
+++ b/library/s3/index.js
@@ -21,11 +21,16 @@ function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
     return Buckets;
   }
 
-  async function getBucket({ bucket='', prefix = undefined } = {}) {
+  async function getBucket({ bucket, prefix = undefined } = {}) {
+    if (!bucket) {
+      rej(`getBucket() requires bucket property`);
+    }
+    console.log('GET BUCKET', bucket, prefix);
     const listParams = {
       Bucket: bucket,
       ...!!prefix && { Delimiter: '/', Prefix: prefix },
     };
+    console.log('LIST PARAMS', listParams);
     const { Contents } = await s3.listObjects(listParams).promise();
     return Contents;
   }

--- a/library/s3/index.js
+++ b/library/s3/index.js
@@ -1,5 +1,6 @@
 const { S3 } = require('aws-sdk');
 const apiVersions = require('../../apiVersions.json');
+const RhinoCloud = require('../index');
 const { getS3UploadParameters, getS3MoveParameters } = require('./toolbox/action.tools');
 const {
   getFilePathsFromDirectory,
@@ -128,7 +129,8 @@ function s3Wrapper() {
 }
 
 // ------------------------------- export ----------------------------- //
-s3Wrapper.prototype = Object.create(s3Wrapper.prototype);
+s3Wrapper.prototype = Object.create(RhinoCloud.prototype);
 s3Wrapper.prototype.constructor = s3Wrapper;
+s3Wrapper.getKeys = RhinoCloud.getKeys;
 
 module.exports = s3Wrapper;

--- a/library/s3/index.js
+++ b/library/s3/index.js
@@ -24,7 +24,7 @@ function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
   async function getBucket({ bucket='', key = undefined } = {}) {
     const listParams = {
       Bucket: bucket,
-      ...!!key && { Delimiter: key },
+      ...!!key && { Delimiter: '/', Prefix: key },
     };
     const { Contents } = await s3.listObjects(listParams).promise();
     return Contents;

--- a/library/s3/index.js
+++ b/library/s3/index.js
@@ -25,12 +25,10 @@ function s3Wrapper({ accessKeyId, secretAccessKey, region }) {
     if (!bucket) {
       rej(`getBucket() requires bucket property`);
     }
-    console.log('GET BUCKET', bucket, prefix);
     const listParams = {
       Bucket: bucket,
-      ...!!prefix && { Delimiter: '/', Prefix: prefix },
+      ...!!prefix && { Prefix: prefix },
     };
-    console.log('LIST PARAMS', listParams);
     const { Contents } = await s3.listObjects(listParams).promise();
     return Contents;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rhinocloud-sdk",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhinocloud-sdk",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Rhinogram's JavaScript-friendly toolbox for CloudFormation deployments",
   "engines": {
     "yarn": "1.x",


### PR DESCRIPTION
This adds the ability to drop in your AWS creds to the RhinoCloud class which then passes them on to CF and S3.  I also add an additional parameter to getBuckets so you can filter your Object returns.  In addition I added a default empty object to functions I found using destruction.  This prevents type errors when the function is called without params.