### PR TITLE
only stringify ENV VAR if exists

### DIFF
--- a/library/helpers.js
+++ b/library/helpers.js
@@ -1,7 +1,7 @@
 
 module.exports.debugLog = (...args) => {
   // boolean will get stringified in process.env for serverless and docker-compose
-  if (process.env.DEBUG.toString() === 'true') {
+  if (process.env.DEBUG && process.env.DEBUG.toString() === 'true') {
     // eslint-disable-next-line
     console.log(...args);
   }


### PR DESCRIPTION
### What should this PR do?
* I have modified the `package.json` to reflect the appropriate version.
* I was experiencing an issue `Cannot read property 'toString' of undefined`. Tracing the issue, I saw it was from the helper function looking for `DEBUG` env var. This fix only attempts to stringify the var if it exists.
