### PR TITLE
Grady/update stack safemode

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ turnOnTerminationProtection();
   * `options` (object) `optional`:
     * `waitToComplete` (boolean):  Wait on a success or failure response (defaults to `true`).
     * `timeout` (number) `optional`: How long in milliseconds to wait, if `waitToComplete` is set to `true`, for the stack to complete before timing out. The CloudFormation stack will continue what it is doing even though the function errors to stop making CloudFormation API calls.
-    * `parameters` (array): CloudFormation parameters that correlate to the CloudFormation template. Each object in the array must contain:
+    * `parameters` (array): CloudFormation parameters that correlate to the CloudFormation template. If the request is an update to an existing stack, existing parameter values are applied to omitted parameters. Each object in the array must contain:
       * `key` (string): Name of the parameter.
       * `value` (any): Value of the parameter.
+    * `protectedResourceTypes` (array) `optional`: AWS Resource types that will cause the function to error out when the ChangeSet calls for `Replacement` (see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
     * `enableTerminationProtection` (boolean) `optional`: Enable termination protection of CloudFormation stack. Only applies to new stacks (defaults to `false`).
 #### Example
 ```bash

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const rhinocloud = new Rhinocloud({
   * `AWS_REGION`
 
 
-* Setting `process.env.DEBUG === true` will enable debug mode.
+* Setting `process.env.DEBUG = true` or `process.env.LOG_LEVEL = 'debug'` will enable debug mode.
 
 * Example using `dotenv` library with `rhinocloud-sdk`: https://www.npmjs.com/package/dotenv
 ```bash

--- a/library/cloudformation/index.js
+++ b/library/cloudformation/index.js
@@ -24,6 +24,7 @@ function CloudFormationWrapper(credentialsOpts) {
     const resp = await cf.updateTerminationProtection(updateParams).promise();
     return resp;
   }
+
   //eslint-disable-next-line consistent-return
   async function cloudForm({ templatePath, stackName, options={} } = {}) {
     if (!templatePath || !stackName) {
@@ -40,16 +41,41 @@ function CloudFormationWrapper(credentialsOpts) {
       waitToComplete,
       parameters,
       enableTerminationProtection,
+      protectedResourceTypes,
     } = getOptions(options);
 
     if (stackAlreadyExists) {
-      await updateStack(stackName, templatePath, parameters);
+      await updateStack(stackName, templatePath, parameters, protectedResourceTypes);
     } else {
       await createStack(templatePath, stackName, parameters, enableTerminationProtection);
     }
     if (waitToComplete) {
       return waitOnStackToStabilize(stackName);
     }
+  }
+
+  async function createChangeSet(templatePath, stackName, parameters) {
+    const changeSetName = `${stackName}-${new Date().getTime()}`;
+    const { Id: changeSetArn } = await cf.createChangeSet({
+      ChangeSetName: changeSetName,
+      Parameters: getCloudFormationParameters(parameters),
+      StackName: stackName,
+      TemplateBody: fs.readFileSync(templatePath, 'utf-8'),
+    }).promise();
+    const describeChangeSetParams = {
+      ChangeSetName: changeSetArn,
+      StackName: stackName,
+    };
+    try {
+      await cf.waitFor('changeSetCreateComplete', { ChangeSetName: changeSetArn }).promise();
+    } catch (error) {
+      if (error.message === 'Resource is not in the state changeSetCreateComplete') {
+        debugLog(`ChangeSet: ${changeSetArn} does not contain any changes.`);
+      } else {
+        throw error;
+      }
+    }
+    return cf.describeChangeSet(describeChangeSetParams).promise();
   }
 
   async function createStack(templatePath, stackName, parameters = [], enableTerminationProtection) {
@@ -124,29 +150,41 @@ function CloudFormationWrapper(credentialsOpts) {
     }
   }
 
-  async function updateStack(stackName, templatePath, parameters = []) {
+  async function updateStack(stackName, templatePath, parameters = [], protectedResourceTypes = []) {
     if (!stackName || !templatePath) {
       throw new Error('Must include stackName (string) and templatesPath (string) for CloudFormation');
     }
-    try {
-      const updateParams = {
-        StackName: stackName,
-        TemplateBody: fs.readFileSync(templatePath, 'utf-8'),
-        Capabilities: ['CAPABILITY_NAMED_IAM', 'CAPABILITY_IAM'],
-        Parameters: getCloudFormationParameters(parameters),
-      };
-      const resp = await cf.updateStack(updateParams).promise();
-      return resp;
-    } catch (error) {
-      const noUpdatesMsg = 'No updates are to be performed.';
-      if (error.message === noUpdatesMsg) {
-        debugLog(noUpdatesMsg);
-        return null;
+
+    const { ExecutionStatus, StatusReason, Changes = [], ChangeSetId } = await createChangeSet(templatePath, stackName, parameters);
+
+    if (ExecutionStatus === 'AVAILABLE') {
+      const resourcesToBeChanged = Changes.map((c) => c.ResourceChange);
+      const problematicUpdates = resourcesToBeChanged.filter(({ Replacement, ResourceType }) => {
+        const isProtectedResource = protectedResourceTypes.includes(ResourceType);
+        return isProtectedResource && Replacement === 'True';
+      });
+      if (problematicUpdates.length > 0) {
+        const problemChangesStr = JSON.stringify(problematicUpdates);
+        throw new Error(`ChangeSet: ${ChangeSetId} would cause the following protected resources to be replaced: ${problemChangesStr}. Not applying changes.`);
+      } else {
+        // apply changes
+        await cf.executeChangeSet({
+          StackName: stackName,
+          ChangeSetName: ChangeSetId,
+        }).promise();
       }
-      throw error;
+    } else if (StatusReason === 'The submitted information didn\'t contain changes. Submit different information to create a change set.') {
+      debugLog(`No changes detected to CloudFormation stack: ${stackName}`);
+
+      // delete ChangeSet
+      await cf.deleteChangeSet({
+        ChangeSetName: ChangeSetId,
+        StackName: stackName,
+      }).promise();
+    } else {
+      throw new Error(`ChangeSet: ${ChangeSetId} execution status is: ${ExecutionStatus} and cannot be applied.`);
     }
   }
-
 
   async function waitOnStackToStabilize(stackName, msLeftBeforeTimeout) {
     if (!stackName) {

--- a/library/cloudformation/toolbox/parameter.tools.js
+++ b/library/cloudformation/toolbox/parameter.tools.js
@@ -12,9 +12,11 @@ module.exports.getOptions = ({
   parameters = [],
   enableTerminationProtection = false,
   timeout,
+  protectedResourceTypes = [],
 }) => ({
   waitToComplete,
   parameters,
   enableTerminationProtection,
   timeout,
+  protectedResourceTypes,
 });

--- a/library/helpers.js
+++ b/library/helpers.js
@@ -1,7 +1,11 @@
 
 module.exports.debugLog = (...args) => {
+  const {
+    DEBUG = '',
+    LOG_LEVEL = '',
+  } = process.env;
   // boolean will get stringified in process.env for serverless and docker-compose
-  if (process.env.DEBUG && process.env.DEBUG.toString() === 'true') {
+  if (DEBUG.toString() === 'true' || LOG_LEVEL.toLowerCase() === 'debug') {
     // eslint-disable-next-line
     console.log(...args);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhinocloud-sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Rhinogram's JavaScript-friendly toolbox for CloudFormation deployments",
   "engines": {
     "yarn": "1.x",


### PR DESCRIPTION
**Related issue link:** (You can delete this line if the PR does not relate to an existing GitHub issue)

### What should this PR do?
* I have modified the `package.json` to reflect the appropriate version.
* Allow for `protectedResourceTypes` array in the `options` parameter for `cloudForm()`. If a specified resource type (like `AWS::RDS::DBInstance`) requires replacement, the function errors out. The ChangeSet is left in CloudFormation for an admin to apply if he or she so chooses.
* If any parameter is omitted from `options.parameters` array, the previous value for said parameter is applied to the update. 
