### PR TITLE
include new parameters not listed in existing template

### DIFF
--- a/library/cloudformation/index.js
+++ b/library/cloudformation/index.js
@@ -59,15 +59,18 @@ function CloudFormationWrapper(credentialsOpts) {
     const changeSetName = `${stackName}-${new Date().getTime()}`;
     const currentParameters = await getStackParameters(stackName);
     const newParameters = getCloudFormationParameters(parameters);
-    const updatedParameters = currentParameters.map(({ ParameterKey, ParameterValue }) => {
-      const newParam = newParameters.find((p) => p.ParameterKey === ParameterKey);
-      if (newParam) {
-        debugLog(`Using new parameter value for ${ParameterKey}`);
-        return { ParameterKey, ParameterValue: newParam.ParameterValue };
-      }
-      debugLog(`Using existing value for ${ParameterKey}`);
-      return { ParameterKey, ParameterValue };
-    });
+    const updatedParameters = currentParameters
+      .map(({ ParameterKey, ParameterValue }) => {
+        const newParam = newParameters.find((p) => p.ParameterKey === ParameterKey);
+        if (newParam) {
+          debugLog(`Using new parameter value for ${ParameterKey}`);
+          return { ParameterKey, ParameterValue: newParam.ParameterValue };
+        }
+        debugLog(`Using existing value for ${ParameterKey}`);
+        return { ParameterKey, ParameterValue };
+      })
+      // add new parameters, not currently listed in the existing template
+      .concat(newParameters.filter(newParam => !currentParameters.find(currParam => currParam.ParameterKey === newParam.ParameterKey)));
 
     const { Id: changeSetArn } = await cf.createChangeSet({
       ChangeSetName: changeSetName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhinocloud-sdk",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Rhinogram's JavaScript-friendly toolbox for CloudFormation deployments",
   "engines": {
     "yarn": "1.x",


### PR DESCRIPTION

### What should this PR do?
* I have modified the `package.json` to reflect the appropriate version.
* Currently when you attempt an update to a stack that includes a new parameter in the template, `rhinocloud-sdk` does not include these new parameters. This resolves this issue.
