### PR TITLE
Expose OnFailure option for creating CloudFormation stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ turnOnTerminationProtection();
     * `protectedResourceTypes` (array) `optional`: AWS Resource types that will cause the function to error out when the ChangeSet calls for `Replacement` (see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html).
     * `enableTerminationProtection` (boolean) `optional`: Enable termination protection of CloudFormation stack. Only applies to new stacks (defaults to `false`).
     * `notificationArns` (array) `optional`: Array of ARN strings that identify SNS Topics that will be triggered on CloudFormation state change.
+    * `onFailure` (string) `optional`: See "OnFailure" option in https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html.
 #### Example
 ```bash
 # template.yml

--- a/library/cloudformation/index.js
+++ b/library/cloudformation/index.js
@@ -90,7 +90,7 @@ function CloudFormationWrapper(credentialsOpts) {
     return cf.describeChangeSet(describeChangeSetParams).promise();
   }
 
-  async function createStack(templatePath, stackName, parameters = [], notificationArns = [], enableTerminationProtection, templateUrl, onFailure = 'ROLLBACK') {
+  async function createStack(templatePath, stackName, parameters = [], notificationArns = [], enableTerminationProtection, templateUrl, onFailure) {
     if ((!templatePath && !templateUrl) || !stackName) {
       throw new Error('Must include templatePath (string) or templateUrl (string) and stackName (string) for CloudFormation');
     }
@@ -105,6 +105,7 @@ function CloudFormationWrapper(credentialsOpts) {
       NotificationARNs: notificationArns,
       OnFailure: onFailure,
     };
+    debugLog(params);
     const resp = await cf.createStack(params).promise();
     return resp;
   }

--- a/library/cloudformation/index.js
+++ b/library/cloudformation/index.js
@@ -43,12 +43,13 @@ function CloudFormationWrapper(credentialsOpts) {
       enableTerminationProtection,
       protectedResourceTypes,
       notificationArns,
+      onFailure,
     } = getOptions(options);
 
     if (stackAlreadyExists) {
       await updateStack(stackName, templatePath, parameters, notificationArns, protectedResourceTypes, templateUrl);
     } else {
-      await createStack(templatePath, stackName, parameters, notificationArns, enableTerminationProtection, templateUrl);
+      await createStack(templatePath, stackName, parameters, notificationArns, enableTerminationProtection, templateUrl, onFailure);
     }
     if (waitToComplete) {
       return waitOnStackToStabilize(stackName);
@@ -68,6 +69,7 @@ function CloudFormationWrapper(credentialsOpts) {
       ...templateUrl && { TemplateURL: templateUrl },
       UsePreviousTemplate: (!templateUrl && !templatePath),
       NotificationARNs: notificationArns,
+      IncludeNestedStacks: true,
     }).promise();
 
     try {
@@ -88,7 +90,7 @@ function CloudFormationWrapper(credentialsOpts) {
     return cf.describeChangeSet(describeChangeSetParams).promise();
   }
 
-  async function createStack(templatePath, stackName, parameters = [], notificationArns = [], enableTerminationProtection, templateUrl) {
+  async function createStack(templatePath, stackName, parameters = [], notificationArns = [], enableTerminationProtection, templateUrl, onFailure = 'ROLLBACK') {
     if ((!templatePath && !templateUrl) || !stackName) {
       throw new Error('Must include templatePath (string) or templateUrl (string) and stackName (string) for CloudFormation');
     }
@@ -101,6 +103,7 @@ function CloudFormationWrapper(credentialsOpts) {
       Capabilities: ['CAPABILITY_NAMED_IAM', 'CAPABILITY_IAM'],
       Parameters: getCloudFormationParameters(parameters),
       NotificationARNs: notificationArns,
+      OnFailure: onFailure,
     };
     const resp = await cf.createStack(params).promise();
     return resp;

--- a/library/cloudformation/toolbox/parameter.tools.js
+++ b/library/cloudformation/toolbox/parameter.tools.js
@@ -14,6 +14,7 @@ module.exports.getOptions = ({
   timeout,
   protectedResourceTypes = [],
   notificationArns = [],
+  onFailure = 'ROLLBACK',
 }) => ({
   waitToComplete,
   parameters,
@@ -21,4 +22,5 @@ module.exports.getOptions = ({
   timeout,
   protectedResourceTypes,
   notificationArns,
+  onFailure,
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhinocloud-sdk",
-  "version": "1.1.81",
+  "version": "1.1.82",
   "description": "Rhinogram's JavaScript-friendly toolbox for CloudFormation deployments",
   "engines": {
     "yarn": "1.x",


### PR DESCRIPTION
### What should this PR do?
* I have modified the `package.json` to reflect the appropriate version.
* provide a `parameters.options.onFailure` option that exposes the `OnFailure` property of the `aws-sdk`.
* Include nested stacks when creating change sets