### PR TITLE
RHIN-7949 Fix the xml error due to deleting the dir without any object

### DIFF
--- a/library/s3/index.js
+++ b/library/s3/index.js
@@ -247,6 +247,8 @@ function s3Wrapper(credentialsOpts) {
         const deleteParams = getS3DeleteParameters({ sourceBucket, sourceS3Files: keyVersionMap, options });
         await s3.deleteObjects(deleteParams).promise();
         debugLog(`deleted ${keyVersionObjects.length} files from S3 Bucket: ${sourceBucket}`);
+      } else {
+        debugLog(`either directory for organization is empty or not present in S3 Bucket: ${sourceBucket}`);
       }
       return undefined;
     }


### PR DESCRIPTION
**Related issue link:** (You can delete this line if the PR does not relate to an existing GitHub issue)
https://rhinogram.atlassian.net/browse/RHIN-7949
### What should this PR do?
* I have modified the `package.json` to reflect the appropriate version.
* <Bullets of what the PR does>

when we are deleting the organization then we are trying to remove the objects from corresponding bucket Avtars and attachment from S3 
And because the Orgs that are created through automated test don't have Avtars and attachment means bucket (rhinoavatar-develop) don't have directory and the objects inside it.
